### PR TITLE
add some logging and structure changes to fix initial install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ Salt is also capable of loading formulas from Git using a [fileserver_backend](h
 The goal of this project is to make it easy to assemble formulas from Git repositories during a build stage running on something like Jenkins. After assembly, all files can be delivered to Salt master(s) in an atomic way. This makes it easier to keep multiple masters sync'd and Docker based Salt master deployments easier.
 
 ## Installation
-
+This requires gitpython, so ensure it is installed first:
+```bash
+sudo pip install gitpython
+```
+Then you can install saltstack-vulcan:
 ```bash
 sudo pip install saltstack-vulcan -U
 ```

--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@ Salt is also capable of loading formulas from Git using a [fileserver_backend](h
 The goal of this project is to make it easy to assemble formulas from Git repositories during a build stage running on something like Jenkins. After assembly, all files can be delivered to Salt master(s) in an atomic way. This makes it easier to keep multiple masters sync'd and Docker based Salt master deployments easier.
 
 ## Installation
-This requires gitpython, so ensure it is installed first:
-```bash
-sudo pip install gitpython
-```
-Then you can install saltstack-vulcan:
+
 ```bash
 sudo pip install saltstack-vulcan -U
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
+import vulcan
 from setuptools import setup
 
 setup(name='saltstack-vulcan',
-    version='0.1.2',
+    version=vulcan.__version__,
     description='Formula build tool for SaltStack.',
     author="Seth Miller",
     author_email='seth@sethmiller.me',
@@ -14,6 +15,6 @@ setup(name='saltstack-vulcan',
     install_requires=[
                       'GitPython>=2.1.3',
                       'PyYAML>=3.12',
-                      'click==6.7',
+                      'click>=6.7',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
-import vulcan
 from setuptools import setup
 
 setup(name='saltstack-vulcan',
-    version=vulcan.__version__,
+    version='0.1.2',
     description='Formula build tool for SaltStack.',
     author="Seth Miller",
     author_email='seth@sethmiller.me',

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(name='saltstack-vulcan',
     install_requires=[
                       'GitPython>=2.1.3',
                       'PyYAML>=3.12',
+                      'click==6.7',
     ],
 )

--- a/vulcan/formula.py
+++ b/vulcan/formula.py
@@ -60,13 +60,13 @@ class Formula(object):
         '''Install formula if not already installed. Will not update if out of date.
         '''
         if not force and self.is_installed():
-            logging.info('Formula %s is already installed, exiting' % (self.name))
+            logging.info('Formula %s is already installed, exiting' % self.name)
             return
 
-        log.info('Getting formula %s', self.name)
+        log.info('Getting formula %s', % self.name)
         # Clone the repository to a temp directory.
         tmpdir = tempfile.mkdtemp()
-        log.debug('tmpdir is %s' %(tmpdir))
+        log.debug('tmpdir is %s' % tmpdir)
         try:
             repo = git.Repo.clone_from(url=self.url, to_path=tmpdir, branch=self.branch)
             repo.head.reset(commit=self.revision, index=True, working_tree=True)

--- a/vulcan/formula.py
+++ b/vulcan/formula.py
@@ -78,7 +78,8 @@ class Formula(object):
 
             # Move formula into place.
             log.info('Moving formula %s to %s' %(self.name, destination))
-            shutil.move(tmpdir, destination)
+            origin = os.path.join(tmpdir, self.origin_name)
+            shutil.move(origin, destination)
 
             # Save state file.
             with open(self.state_file, 'w') as fh:

--- a/vulcan/formula.py
+++ b/vulcan/formula.py
@@ -85,9 +85,6 @@ class Formula(object):
             with open(self.state_file, 'w') as fh:
                 json.dump(self.as_dict(), fh)
 
-        except Exception as e:
-            log.error('Could not get formula: %s , exception: %s' % (self.name, e))
-
         finally:
             log.debug('Removing tmpdir %s' % tmpdir)
             if os.path.isdir(tmpdir):

--- a/vulcan/formula.py
+++ b/vulcan/formula.py
@@ -88,7 +88,7 @@ class Formula(object):
             log.error('Could not get formula: %s , exception: %s' % (self.name, e))
 
         finally:
-            log.debug('Removing tmpdir %s' %(tmpdir))
+            log.debug('Removing tmpdir %s' % tmpdir)
             if os.path.isdir(tmpdir):
                 shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
The initial install process tries to import vulcan (to get the __version__) but if vulcan isn't installed, this will fail. I removed the import and set version to a str matching vulcan.__version__

added some logging to help troubleshoot an issue I was seeing with the formula install, and I realized - at least on my box (heh) that the following code failed:
```bash
origin = os.path.join(tmpdir, self.origin_name)
shutil.move(origin, destination)
```
origin got set to tmpdir/.git when what really needed to happen is the whole tmpdir get moved to destination - since we remove tmpdir and re-create it for each formula, this shouldn't be a problem. 

an alternate fix would be to make a self.name folder under tmpdir and clone to that, then set origin to tmpdir/self.name - but I figured this was the simpler fix.

I've tested this a few times in a venv on osx with python 2.7 as follows:
```bash
First we verify nothing is installed in a fresh venv:
Variks:~ badger$ source saltstack-vulcan/bin/activate
(saltstack-vulcan) Variks:~ badger$ pip freeze
appdirs==1.4.3
packaging==16.8
pyparsing==2.2.0
six==1.10.0
Then we try to install from setup.py:

(saltstack-vulcan) Variks:saltstack-vulcan badger$ python setup.py install
running install
running bdist_egg
running egg_info
writing requirements to saltstack_vulcan.egg-info/requires.txt
writing saltstack_vulcan.egg-info/PKG-INFO
writing top-level names to saltstack_vulcan.egg-info/top_level.txt
writing dependency_links to saltstack_vulcan.egg-info/dependency_links.txt
reading manifest file 'saltstack_vulcan.egg-info/SOURCES.txt'
writing manifest file 'saltstack_vulcan.egg-info/SOURCES.txt'
installing library code to build/bdist.macosx-10.12-intel/egg
running install_lib
running build_py
creating build/bdist.macosx-10.12-intel/egg
creating build/bdist.macosx-10.12-intel/egg/vulcan
copying build/lib/vulcan/__init__.py -> build/bdist.macosx-10.12-intel/egg/vulcan
copying build/lib/vulcan/cli.py -> build/bdist.macosx-10.12-intel/egg/vulcan
copying build/lib/vulcan/config.py -> build/bdist.macosx-10.12-intel/egg/vulcan
copying build/lib/vulcan/formula.py -> build/bdist.macosx-10.12-intel/egg/vulcan
copying build/lib/vulcan/util.py -> build/bdist.macosx-10.12-intel/egg/vulcan
byte-compiling build/bdist.macosx-10.12-intel/egg/vulcan/__init__.py to __init__.pyc
byte-compiling build/bdist.macosx-10.12-intel/egg/vulcan/cli.py to cli.pyc
byte-compiling build/bdist.macosx-10.12-intel/egg/vulcan/config.py to config.pyc
byte-compiling build/bdist.macosx-10.12-intel/egg/vulcan/formula.py to formula.pyc
byte-compiling build/bdist.macosx-10.12-intel/egg/vulcan/util.py to util.pyc
creating build/bdist.macosx-10.12-intel/egg/EGG-INFO
installing scripts to build/bdist.macosx-10.12-intel/egg/EGG-INFO/scripts
running install_scripts
running build_scripts
creating build/bdist.macosx-10.12-intel/egg/EGG-INFO/scripts
copying build/scripts-2.7/vulcan -> build/bdist.macosx-10.12-intel/egg/EGG-INFO/scripts
changing mode of build/bdist.macosx-10.12-intel/egg/EGG-INFO/scripts/vulcan to 755
copying saltstack_vulcan.egg-info/PKG-INFO -> build/bdist.macosx-10.12-intel/egg/EGG-INFO
copying saltstack_vulcan.egg-info/SOURCES.txt -> build/bdist.macosx-10.12-intel/egg/EGG-INFO
copying saltstack_vulcan.egg-info/dependency_links.txt -> build/bdist.macosx-10.12-intel/egg/EGG-INFO
copying saltstack_vulcan.egg-info/requires.txt -> build/bdist.macosx-10.12-intel/egg/EGG-INFO
copying saltstack_vulcan.egg-info/top_level.txt -> build/bdist.macosx-10.12-intel/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
creating 'dist/saltstack_vulcan-0.1.2-py2.7.egg' and adding 'build/bdist.macosx-10.12-intel/egg' to it
removing 'build/bdist.macosx-10.12-intel/egg' (and everything under it)
Processing saltstack_vulcan-0.1.2-py2.7.egg
Copying saltstack_vulcan-0.1.2-py2.7.egg to /Users/badger/saltstack-vulcan/lib/python2.7/site-packages
Adding saltstack-vulcan 0.1.2 to easy-install.pth file
Installing vulcan script to /Users/badger/saltstack-vulcan/bin

Installed /Users/badger/saltstack-vulcan/lib/python2.7/site-packages/saltstack_vulcan-0.1.2-py2.7.egg
Processing dependencies for saltstack-vulcan==0.1.2
Searching for click==6.7
Reading https://pypi.python.org/simple/click/
Downloading https://pypi.python.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz#md5=fc4cc00c4863833230d3af92af48abd4
Best match: click 6.7
Processing click-6.7.tar.gz
Writing /var/folders/j9/j60g11dx0nbdh34lyqcgdy5c0000gn/T/easy_install-tWc134/click-6.7/setup.cfg
Running click-6.7/setup.py -q bdist_egg --dist-dir /var/folders/j9/j60g11dx0nbdh34lyqcgdy5c0000gn/T/easy_install-tWc134/click-6.7/egg-dist-tmp-TeJsTt
warning: no previously-included files matching '*.pyc' found under directory 'docs'
warning: no previously-included files matching '*.pyo' found under directory 'docs'
warning: no previously-included files matching '*.pyc' found under directory 'tests'
warning: no previously-included files matching '*.pyo' found under directory 'tests'
warning: no previously-included files matching '*.pyc' found under directory 'examples'
warning: no previously-included files matching '*.pyo' found under directory 'examples'
no previously-included directories found matching 'docs/_build'
zip_safe flag not set; analyzing archive contents...
click.core: module references __file__
creating /Users/badger/saltstack-vulcan/lib/python2.7/site-packages/click-6.7-py2.7.egg
Extracting click-6.7-py2.7.egg to /Users/badger/saltstack-vulcan/lib/python2.7/site-packages
Adding click 6.7 to easy-install.pth file

Installed /Users/badger/saltstack-vulcan/lib/python2.7/site-packages/click-6.7-py2.7.egg
Searching for GitPython>=2.1.3
Reading https://pypi.python.org/simple/GitPython/
Downloading https://pypi.python.org/packages/e8/87/a1cdd8b210e4b825ec34fef996d2680dc00ee9517379c167e9a57af0664e/GitPython-2.1.3.tar.gz#md5=6cd18008c03a767740f3bf6d89ef79bc
Best match: GitPython 2.1.3
Processing GitPython-2.1.3.tar.gz
Writing /var/folders/j9/j60g11dx0nbdh34lyqcgdy5c0000gn/T/easy_install-JxfQsz/GitPython-2.1.3/setup.cfg
Running GitPython-2.1.3/setup.py -q bdist_egg --dist-dir /var/folders/j9/j60g11dx0nbdh34lyqcgdy5c0000gn/T/easy_install-JxfQsz/GitPython-2.1.3/egg-dist-tmp-Qbp_um
/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'test_requirements'
  warnings.warn(msg)
warning: no files found matching 'README'
warning: no previously-included files matching '__pycache__' found anywhere in distribution
warning: no previously-included files matching '*.pyc' found anywhere in distribution
creating /Users/badger/saltstack-vulcan/lib/python2.7/site-packages/GitPython-2.1.3-py2.7.egg
Extracting GitPython-2.1.3-py2.7.egg to /Users/badger/saltstack-vulcan/lib/python2.7/site-packages
Adding GitPython 2.1.3 to easy-install.pth file

Installed /Users/badger/saltstack-vulcan/lib/python2.7/site-packages/GitPython-2.1.3-py2.7.egg
Searching for gitdb2>=2.0.0
Reading https://pypi.python.org/simple/gitdb2/
Downloading https://pypi.python.org/packages/5c/bb/ab74c6914e3b570ab2e960fda17a01aec93474426eecd3b34751ba1c3b38/gitdb2-2.0.0.tar.gz#md5=78fdc7645665067862e3ba1e02db6884
Best match: gitdb2 2.0.0
Processing gitdb2-2.0.0.tar.gz
Writing /var/folders/j9/j60g11dx0nbdh34lyqcgdy5c0000gn/T/easy_install-ECVUom/gitdb2-2.0.0/setup.cfg
Running gitdb2-2.0.0/setup.py -q bdist_egg --dist-dir /var/folders/j9/j60g11dx0nbdh34lyqcgdy5c0000gn/T/easy_install-ECVUom/gitdb2-2.0.0/egg-dist-tmp-27N5qo
warning: no files found matching 'VERSION'
warning: no files found matching 'CHANGES'
warning: no files found matching 'README'
warning: no files found matching 'gitdb/_fun.c'
warning: no files found matching 'gitdb/_delta_apply.c'
warning: no files found matching 'gitdb/_delta_apply.h'
warning: no previously-included files matching '.git*' found anywhere in distribution
warning: no previously-included files matching '*.pyc' found anywhere in distribution
warning: no previously-included files matching '*.so' found anywhere in distribution
warning: no previously-included files matching '*.dll' found anywhere in distribution
warning: no previously-included files matching '*.o' found anywhere in distribution
creating /Users/badger/saltstack-vulcan/lib/python2.7/site-packages/gitdb2-2.0.0-py2.7.egg
Extracting gitdb2-2.0.0-py2.7.egg to /Users/badger/saltstack-vulcan/lib/python2.7/site-packages
Adding gitdb2 2.0.0 to easy-install.pth file

Installed /Users/badger/saltstack-vulcan/lib/python2.7/site-packages/gitdb2-2.0.0-py2.7.egg
Searching for smmap2>=2.0.0
Reading https://pypi.python.org/simple/smmap2/
Downloading https://pypi.python.org/packages/83/ce/e5b3aee7ca420b0ab24d4fcc2aa577f7aa6ea7e9306fafceabee3e8e4703/smmap2-2.0.1.tar.gz#md5=71565e9c99ab64718e2a13c489767692
Best match: smmap2 2.0.1
Processing smmap2-2.0.1.tar.gz
Writing /var/folders/j9/j60g11dx0nbdh34lyqcgdy5c0000gn/T/easy_install-IS0YyB/smmap2-2.0.1/setup.cfg
Running smmap2-2.0.1/setup.py -q bdist_egg --dist-dir /var/folders/j9/j60g11dx0nbdh34lyqcgdy5c0000gn/T/easy_install-IS0YyB/smmap2-2.0.1/egg-dist-tmp-wl2KhG
Copying smmap2-2.0.1-py2.7.egg to /Users/badger/saltstack-vulcan/lib/python2.7/site-packages
Adding smmap2 2.0.1 to easy-install.pth file

Installed /Users/badger/saltstack-vulcan/lib/python2.7/site-packages/smmap2-2.0.1-py2.7.egg
Searching for PyYAML==3.12
Best match: PyYAML 3.12
Adding PyYAML 3.12 to easy-install.pth file

Using /Users/badger/saltstack-vulcan/lib/python2.7/site-packages
Finished processing dependencies for saltstack-vulcan==0.1.2
Finally, verify they installed as expected:
(saltstack-vulcan) Variks:saltstack-vulcan badger$ pip freeze
appdirs==1.4.3
click==6.7
gitdb2==2.0.0
GitPython==2.1.3
packaging==16.8
pyparsing==2.2.0
PyYAML==3.12
saltstack-vulcan==0.1.2
six==1.10.0
smmap2==2.0.1
```